### PR TITLE
Reintroduce Welcome Message

### DIFF
--- a/src/main/java/duke/core/Main.java
+++ b/src/main/java/duke/core/Main.java
@@ -35,6 +35,7 @@ public class Main extends Application {
             Scene scene = new Scene(ap);
             stage.setScene(scene);
             fxmlLoader.<MainWindow>getController().setDuke(duke);
+            fxmlLoader.<MainWindow>getController().showWelcome();
             stage.show();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -17,6 +17,8 @@ import javafx.scene.layout.VBox;
  * Controller for MainWindow. Provides the layout for the other controls.
  */
 public class MainWindow extends AnchorPane {
+
+    private static final String WELCOME_MESSAGE = "Hi! I am Duke! Let's have a chat!";
     @FXML
     private ScrollPane scrollPane;
     @FXML
@@ -29,6 +31,7 @@ public class MainWindow extends AnchorPane {
     private Duke duke;
     private final Image userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
     private final Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/duke.png"));
+
 
     @FXML
     public void initialize() {
@@ -52,6 +55,15 @@ public class MainWindow extends AnchorPane {
                 DukeDialogBox.of(response, dukeImage)
         );
         userInput.clear();
+    }
+
+    /**
+     * Shows the welcome message in the main window.
+     */
+    public void showWelcome() {
+        dialogContainer.getChildren().addAll(
+                DukeDialogBox.of(WELCOME_MESSAGE, dukeImage)
+        );
     }
 
     /**


### PR DESCRIPTION
Currently, the welcome message is mistakenly removed when moving to JavaFX UI.

Without it, the user starts up to an empty window, which makes Duke seem incomplete.

Reintroducing it in the MainWindow makes sense because it is the new equivalent to the old Ui class, where the message used to be displayed.

Let's
- reintroduce the welcome message in MainWindow
- add a bit of personality to it